### PR TITLE
chore: ClientRepoConfig 클래스와 ServerRepoConfig 클래스의 이름을 ClientConfig, ServerConfig로 변경

### DIFF
--- a/nest_clinet_0616/src/org/kosa/nest/common/ClientConfig.java
+++ b/nest_clinet_0616/src/org/kosa/nest/common/ClientConfig.java
@@ -2,7 +2,7 @@ package org.kosa.nest.common;
 
 import java.io.File;
 
-public interface ClientRepoConfig {
+public interface ClientConfig {
 	String WINDOW_REPOPATH = "C:" + File.separator + "nest";
 	String UNIX_LINUX_REPOPATH = File.separator + "Users" + File.separator 
 			+ System.getProperty("user.name")+ File.separator +"nest";

--- a/nest_server_0616/src/org/kosa/nest/common/ServerConfig.java
+++ b/nest_server_0616/src/org/kosa/nest/common/ServerConfig.java
@@ -2,7 +2,7 @@ package org.kosa.nest.common;
 
 import java.io.File;
 
-public class ServerRepoConfig {
+public class ServerConfig {
 	String WINDOW_REPOPATH = "C:" + File.separator + "nest";
 	String UNIX_LINUX_REPOPATH = File.separator + "Users" + File.separator 
 			+ System.getProperty("user.name")+ File.separator +"nest";


### PR DESCRIPTION
개요
1. 공통 클래스 ClientRepoConfig와 ServerRepoConfig의 이름이 부적절하다고 생각하여 ClientConfig, ServerConfig 로 변경하였습니다