### PR TITLE
feat : AdminDao에 register 회원 가입, getAdmininfo 관리자 정보 조회, updateAdminInfo 관리자 정보 수정 을 구현했습니다.

### DIFF
--- a/nest_server_0616/src/org/kosa/nest/model/AdminDao.java
+++ b/nest_server_0616/src/org/kosa/nest/model/AdminDao.java
@@ -14,7 +14,7 @@ public class AdminDao {
 
 	// 1. register : 회원 가입
 	public int register(AdminVO admin) throws SQLException {
-		String sql = "INSERT INTO admin (id,email, password) VALUES(?,?,?)";
+		String sql = "INSERT INTO admin (id,email, password) VALUES(?,?,?)"; // Id,Email,Password 순으로 입력
 		try {
 			pstmt = conn.prepareStatement(sql);			
 			pstmt.setInt(1, admin.getId());
@@ -29,7 +29,7 @@ public class AdminDao {
 
 	// 2. getAdminInfo : ID로 관리자 정보 조회
 	public AdminVO getAdminInfo(int id) throws SQLException {
-		String sql = "SELECT id, email, password FROM admin WHERE id = ?";
+		String sql = "SELECT id, email, password FROM admin WHERE id = ?"; // Id를 통해 관리자 정보를 조회
 		try {
 			pstmt = conn.prepareStatement(sql);
 			pstmt.setInt(1, id);
@@ -45,7 +45,7 @@ public class AdminDao {
 
 	// 3. updateAdminInfo : 관리자 정보 수정
 	public int updateAdminInfo(AdminVO admin) throws SQLException {
-		String sql = "UPDATE admin SET email = ?, password = ? WHERE id = ?";
+		String sql = "UPDATE admin SET email = ?, password = ? WHERE id = ?"; // Id를 찾아 email과 password를 수정하도록 구현
 		try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
 			pstmt.setString(1, admin.getEmail());
 			pstmt.setString(2, admin.getPassword());

--- a/nest_server_0616/src/org/kosa/nest/model/AdminDao.java
+++ b/nest_server_0616/src/org/kosa/nest/model/AdminDao.java
@@ -1,5 +1,56 @@
 package org.kosa.nest.model;
 
-public class AdminDao {
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
+import org.kosa.nest.common.DatabaseUtil;
+
+public class AdminDao {
+	private Connection conn;
+	private PreparedStatement pstmt;
+	private ResultSet rs;
+
+	// 1. register : 회원 가입
+	public int register(AdminVO admin) throws SQLException {
+		String sql = "INSERT INTO admin (id,email, password) VALUES(?,?,?)";
+		try {
+			pstmt = conn.prepareStatement(sql);			
+			pstmt.setInt(1, admin.getId());
+			pstmt.setString(2, admin.getEmail());
+			pstmt.setString(3, admin.getPassword());
+
+			return pstmt.executeUpdate();
+		} finally {
+			DatabaseUtil.closeAll(pstmt, conn);
+		}
+	}
+
+	// 2. getAdminInfo : ID로 관리자 정보 조회
+	public AdminVO getAdminInfo(int id) throws SQLException {
+		String sql = "SELECT id, email, password FROM admin WHERE id = ?";
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setInt(1, id);
+			rs = pstmt.executeQuery();
+			if (rs.next()) {
+				return new AdminVO(rs.getInt("id"), rs.getString("email"), rs.getString("password"));
+			}
+		} finally {
+			DatabaseUtil.closeAll(rs, pstmt, conn);
+		}
+		return null; // 해당 ID의 관리자가 없는 경우
+	}
+
+	// 3. updateAdminInfo : 관리자 정보 수정
+	public int updateAdminInfo(AdminVO admin) throws SQLException {
+		String sql = "UPDATE admin SET email = ?, password = ? WHERE id = ?";
+		try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
+			pstmt.setString(1, admin.getEmail());
+			pstmt.setString(2, admin.getPassword());
+			pstmt.setInt(3, admin.getId());
+			return pstmt.executeUpdate();
+		}
+	}
 }

--- a/nest_server_0616/src/org/kosa/nest/test/AdminDaoTest.java
+++ b/nest_server_0616/src/org/kosa/nest/test/AdminDaoTest.java
@@ -1,0 +1,19 @@
+package org.kosa.nest.test;
+
+import org.kosa.nest.model.AdminDao;
+import org.kosa.nest.model.AdminVO;
+
+public class AdminDaoTest {
+	public static void main(String[] args) {
+		AdminDao dao = new AdminDao();
+		AdminVO vo1 = new AdminVO(2,"nest1@naver.com","1234"); // 테스트용 객체
+		try {
+			int accountNo = dao.register(vo1); // register 메서드 호출과 결과
+			System.out.println("등록 완료. 계정 번호 : " + accountNo);
+		} catch(Exception e) {
+			System.out.println("등록 실패 : " + e.getMessage());
+			e.printStackTrace();
+		}
+	}
+    
+}


### PR DESCRIPTION
* 개요 *
이 PR은 AdminDao 부분을 구현했습니다.
관리자가 회원가입을 통해 들어오게 되면 관리자의 정보를 조회 할 수 있고, 관리자 정보를 조회 시에 수정 할 부분이 있다면 수정을 할 수 있게 했습니다.

* 구현 내용*
- AdminDao에 JDBC를 사용해 다음 SQL 쿼리를 실행하도록 구현했습니다.
'INSERT INTO admin (id,email, password) VALUES(?,?,?)',
'SELECT id, email, password FROM admin WHERE id = ?',
'UPDATE admin SET email = ?, password = ? WHERE id = ?'

* 테스트 방법*
- 'AdminDaoTest'의 내용대로 테스트 할 수 있습니다.