### PR TITLE
feat : register 테스트 할 때는 직접 객체를 입력하여 했지만 scanner를 통해 제공을 받고 이메일, 비밀번호를 입력 받게 했으며, 계정 번호(ID)를 등록이 되면 자동으로 번호를 부여하게 했고, getAdminIfo에서는 조회할 관리자 ID를 입력하면 그에 맞는 정보를 추출하게 했고, update에서는 getAdminInfo에서 조회한 관리자의 정보를 수정하게 했고 수정 완료를 하면 수정된 정보를 보이게 했습니다.

### DIFF
--- a/nest_server_0616/src/org/kosa/nest/model/AdminDao.java
+++ b/nest_server_0616/src/org/kosa/nest/model/AdminDao.java
@@ -14,6 +14,7 @@ public class AdminDao {
 
 	// 1. register : 회원 가입
 	public int register(AdminVO admin) throws SQLException {
+		conn = DatabaseUtil.getConnection();
 		String sql = "INSERT INTO admin (id,email, password) VALUES(?,?,?)"; // Id,Email,Password 순으로 입력
 		try {
 			pstmt = conn.prepareStatement(sql);			
@@ -29,6 +30,7 @@ public class AdminDao {
 
 	// 2. getAdminInfo : ID로 관리자 정보 조회
 	public AdminVO getAdminInfo(int id) throws SQLException {
+		conn = DatabaseUtil.getConnection();
 		String sql = "SELECT id, email, password FROM admin WHERE id = ?"; // Id를 통해 관리자 정보를 조회
 		try {
 			pstmt = conn.prepareStatement(sql);
@@ -36,15 +38,18 @@ public class AdminDao {
 			rs = pstmt.executeQuery();
 			if (rs.next()) {
 				return new AdminVO(rs.getInt("id"), rs.getString("email"), rs.getString("password"));
+			}else {
+				throw new SQLException("해당 ID가 존재하지 않습니다. ID : "+ id);
 			}
 		} finally {
 			DatabaseUtil.closeAll(rs, pstmt, conn);
 		}
-		return null; // 해당 ID의 관리자가 없는 경우
+
 	}
 
 	// 3. updateAdminInfo : 관리자 정보 수정
 	public int updateAdminInfo(AdminVO admin) throws SQLException {
+		conn = DatabaseUtil.getConnection();
 		String sql = "UPDATE admin SET email = ?, password = ? WHERE id = ?"; // Id를 찾아 email과 password를 수정하도록 구현
 		try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
 			pstmt.setString(1, admin.getEmail());

--- a/nest_server_0616/src/org/kosa/nest/model/AdminDao.java
+++ b/nest_server_0616/src/org/kosa/nest/model/AdminDao.java
@@ -14,7 +14,7 @@ public class AdminDao {
 
 	// 1. register : 회원 가입
 	public int register(AdminVO admin) throws SQLException {
-		String sql = "INSERT INTO admin (id,email, password) VALUES(?,?,?)";
+		String sql = "INSERT INTO admin (id,email, password) VALUES(?,?,?)"; // Id,Email,Password 순으로 입력
 		try {
 			pstmt = conn.prepareStatement(sql);			
 			pstmt.setInt(1, admin.getId());
@@ -29,7 +29,7 @@ public class AdminDao {
 
 	// 2. getAdminInfo : ID로 관리자 정보 조회
 	public AdminVO getAdminInfo(int id) throws SQLException {
-		String sql = "SELECT id, email, password FROM admin WHERE id = ?";
+		String sql = "SELECT id, email, password FROM admin WHERE id = ?"; // Id를 통해 관리자 정보를 조회
 		try {
 			pstmt = conn.prepareStatement(sql);
 			pstmt.setInt(1, id);
@@ -45,7 +45,7 @@ public class AdminDao {
 
 	// 3. updateAdminInfo : 관리자 정보 수정
 	public int updateAdminInfo(AdminVO admin) throws SQLException {
-		String sql = "UPDATE admin SET email = ?, password = ? WHERE id = ?";
+		String sql = "UPDATE admin SET email = ?, password = ? WHERE id = ?"; // Id를 찾아 email과 password를 수정하도록 구현
 		try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
 			pstmt.setString(1, admin.getEmail());
 			pstmt.setString(2, admin.getPassword());

--- a/nest_server_0616/src/org/kosa/nest/model/AdminDao.java
+++ b/nest_server_0616/src/org/kosa/nest/model/AdminDao.java
@@ -1,5 +1,56 @@
 package org.kosa.nest.model;
 
-public class AdminDao {
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
+import org.kosa.nest.common.DatabaseUtil;
+
+public class AdminDao {
+	private Connection conn;
+	private PreparedStatement pstmt;
+	private ResultSet rs;
+
+	// 1. register : 회원 가입
+	public int register(AdminVO admin) throws SQLException {
+		String sql = "INSERT INTO admin (id,email, password) VALUES(?,?,?)";
+		try {
+			pstmt = conn.prepareStatement(sql);			
+			pstmt.setInt(1, admin.getId());
+			pstmt.setString(2, admin.getEmail());
+			pstmt.setString(3, admin.getPassword());
+
+			return pstmt.executeUpdate();
+		} finally {
+			DatabaseUtil.closeAll(pstmt, conn);
+		}
+	}
+
+	// 2. getAdminInfo : ID로 관리자 정보 조회
+	public AdminVO getAdminInfo(int id) throws SQLException {
+		String sql = "SELECT id, email, password FROM admin WHERE id = ?";
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setInt(1, id);
+			rs = pstmt.executeQuery();
+			if (rs.next()) {
+				return new AdminVO(rs.getInt("id"), rs.getString("email"), rs.getString("password"));
+			}
+		} finally {
+			DatabaseUtil.closeAll(rs, pstmt, conn);
+		}
+		return null; // 해당 ID의 관리자가 없는 경우
+	}
+
+	// 3. updateAdminInfo : 관리자 정보 수정
+	public int updateAdminInfo(AdminVO admin) throws SQLException {
+		String sql = "UPDATE admin SET email = ?, password = ? WHERE id = ?";
+		try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
+			pstmt.setString(1, admin.getEmail());
+			pstmt.setString(2, admin.getPassword());
+			pstmt.setInt(3, admin.getId());
+			return pstmt.executeUpdate();
+		}
+	}
 }

--- a/nest_server_0616/src/org/kosa/nest/test/AdminDaoTest.java
+++ b/nest_server_0616/src/org/kosa/nest/test/AdminDaoTest.java
@@ -1,0 +1,19 @@
+package org.kosa.nest.test;
+
+import org.kosa.nest.model.AdminDao;
+import org.kosa.nest.model.AdminVO;
+
+public class AdminDaoTest {
+	public static void main(String[] args) {
+		AdminDao dao = new AdminDao();
+		AdminVO vo1 = new AdminVO(2,"nest1@naver.com","1234"); // 테스트용 객체
+		try {
+			int accountNo = dao.register(vo1); // register 메서드 호출과 결과
+			System.out.println("등록 완료. 계정 번호 : " + accountNo);
+		} catch(Exception e) {
+			System.out.println("등록 실패 : " + e.getMessage());
+			e.printStackTrace();
+		}
+	}
+    
+}

--- a/nest_server_0616/src/org/kosa/nest/test/AdminDaoTest.java
+++ b/nest_server_0616/src/org/kosa/nest/test/AdminDaoTest.java
@@ -1,19 +1,58 @@
 package org.kosa.nest.test;
 
+import java.util.Scanner;
+
 import org.kosa.nest.model.AdminDao;
 import org.kosa.nest.model.AdminVO;
 
 public class AdminDaoTest {
 	public static void main(String[] args) {
 		AdminDao dao = new AdminDao();
-		AdminVO vo1 = new AdminVO(2,"nest1@naver.com","1234"); // 테스트용 객체
+		Scanner sc = new Scanner(System.in); // 테스트용 객체
 		try {
-			int accountNo = dao.register(vo1); // register 메서드 호출과 결과
+			// 1. register 테스트
+			System.out.print("등록할 관리자 이메일 입력: ");
+            String email = sc.nextLine();
+            System.out.print("등록할 관리자 비밀번호 입력: ");
+            String password = sc.nextLine();
+            
+            AdminVO vo = new AdminVO(0,email,password);
+			int accountNo = dao.register(vo); // register 메서드 호출과 결과
 			System.out.println("등록 완료. 계정 번호 : " + accountNo);
+			
+			// 2. getAdminInfo 테스트
+			System.out.print("조회할 관리자 ID를 입력하세요: ");
+			int searchId = Integer.parseInt(sc.nextLine());
+			AdminVO retrievedAdmin = dao.getAdminInfo(searchId); 
+			if (retrievedAdmin != null) {
+			    System.out.println("조회된 관리자 정보: " + retrievedAdmin.getId() + ", " + retrievedAdmin.getEmail() + ", " + retrievedAdmin.getPassword());
+			} else {
+			    System.out.println("해당 ID의 관리자가 존재하지 않습니다.");
+			}
+
+            // 3. updateAdminInfo 테스트 (비밀번호 변경 등)
+            System.out.print("수정할 이메일 입력: ");
+            String newEmail = sc.nextLine();
+            System.out.print("수정할 비밀번호 입력: ");
+            String newPassword = sc.nextLine();
+
+            retrievedAdmin.setEmail(newEmail);
+            retrievedAdmin.setPassword(newPassword);
+            dao.updateAdminInfo(retrievedAdmin);
+            System.out.println("관리자 정보 수정 완료.");
+
+            // 4. 수정된 결과 다시 조회
+            AdminVO updatedAdmin = dao.getAdminInfo(searchId); // 사용자가 입력한 ID 기준으로 조회
+            if (updatedAdmin != null) {
+                System.out.println("수정된 관리자 정보: " + updatedAdmin.getId() + ", " + updatedAdmin.getEmail() + ", " + updatedAdmin.getPassword());
+            } else {
+                System.out.println("수정된 정보를 찾을 수 없습니다.");
+            }
 		} catch(Exception e) {
 			System.out.println("등록 실패 : " + e.getMessage());
 			e.printStackTrace();
+		}finally {
+			sc.close();
 		}
 	}
-    
 }


### PR DESCRIPTION
- 개요
이 PR는 AdminDao 를 생성하였고, register, getAdminInfo, updateAdminInfo의 기능을 추가했습니다.
관리자는 회원가입을 하고, 회원이 되었다면 관리자의 정보를 보여주고, 관리자의 정보를 수정할 수 있게 합니다.

- 구현 내용
AdminDao에서 JDBC를 사용해 다음 SQL 쿼리를 실행하도록 구현했습니다.
'INSERT INTO admin (id,email, password) VALUES(?,?,?)'
'SELECT id, email, password FROM admin WHERE id = ?'
'UPDATE admin SET email = ?, password = ? WHERE id = ?'

- 테스트 방법
 AdminDaoTest에 있는 객체에 필요한 email,password를 입력하면 제공 받는 번호(ID)가 존재합니다.
조회를 할 때 제공 받은 ID를 입력하면 입력했던 email,password가 나옵니다.
후에 수정을 진행 할 때는 조회한 ID에 정보를 수정하게 했으며 email, password를 입력하면 관리자 정보 수정 완료라 뜨면서 수정된 정보가 나오게 했습니다.