### PR TITLE
fix: ServerWorker가 sendResult 메서드를 통하여 client에게 fileVO 와 file을 전송할 때, oos 하나만을 사용하여 전송하도록 수정

### DIFF
--- a/nest_server_0616/src/org/kosa/nest/network/NetworkWorker.java
+++ b/nest_server_0616/src/org/kosa/nest/network/NetworkWorker.java
@@ -21,6 +21,11 @@ public class NetworkWorker {
 
 	private ServerUserService serverUserService;
 	
+	//생성자로 ServerUserService를 받아옴
+	public NetworkWorker(ServerUserService serverUserService) {
+		this.serverUserService = serverUserService;
+	}
+	
 	/**
 	 * 네트워크 접속을 시작하는 메서드 <br>
 	 * ServerSocket을 생성하고 accept() 메서드를 실행하여 접속 가능한 상태로 만든 뒤, <br>
@@ -88,7 +93,6 @@ public class NetworkWorker {
 		 */
 		public void sendResult(String command) throws IOException {
 			
-			BufferedOutputStream bfos = null;
 			ObjectOutputStream oos = null;
 			BufferedInputStream bis = null;
 
@@ -96,15 +100,14 @@ public class NetworkWorker {
 				if(command.equalsIgnoreCase("download")) {
 					FileVO downloadFile = serverUserService.download(command);
 					oos.writeObject(downloadFile);
-					oos.close();
+					oos.flush();
 					bis = new BufferedInputStream(new FileInputStream(downloadFile.getFileLocation()), 8192);
-					bfos = new BufferedOutputStream(socket.getOutputStream());
 					int data = bis.read();
 					while(data != -1) {
-						bfos.write(data);
+						oos.write(data);
 						bis.read();
 					}
-					bfos.close();
+					oos.flush();
 				}
 				else if(command.equalsIgnoreCase("list") || command.equals("search")) {
 					ArrayList<FileVO> searchFileList = serverUserService.search(command);
@@ -117,8 +120,6 @@ public class NetworkWorker {
 					oos.writeObject(infoFileList);
 				}
 			} finally {
-				if(bfos != null)
-					bfos.close();
 				if(oos != null)
 					oos.close();
 				if(bis != null)


### PR DESCRIPTION
개요

ServerWorker가 sendResult 메서드를 통하여 client에게 fileVO와 file을 전송할 때,
ObjectOuputStream과 BufferedOutputStream을 사용해서 전달하려고 했지만,
중간에  oos를 close하면 sokcet의 stream이 닫혀버리는 문제가 발생하는것을
남주님이 mockServer를 이용한 테스트를 통해서 알아내셨고
해당 내용을 수정하였습니다.