### PR TITLE
Feat/soon hyeong admin delete file

### DIFF
--- a/nest_server_0616/src/org/kosa/nest/service/ServerAdminService.java
+++ b/nest_server_0616/src/org/kosa/nest/service/ServerAdminService.java
@@ -65,7 +65,7 @@ public class ServerAdminService {
 	 * @param command
 	 * @return
 	 */
-    public boolean delete(String fileName) {
+    public boolean deleteFile(String fileName) {
     	
         File file = new File(ServerConfig.REPOPATH + fileName);
         boolean result = false;


### PR DESCRIPTION
개요

관리자가 파일을 저장소에서 삭제하게 하는 기능인 deleteFile 입니다.
명령어를 통하여 파일 이름을 메서드의 인자로 받아 해당하는 파일을 디렉토리와 파일정보 데이터베이스에서 삭제합니다.
파일은 file.delete()를 사용하여 삭제하고, 데이터베이스는 fileDao로 delete문을 사용하여 삭제합니다