### PR TITLE
fix : 클라이언트 다운로드 요청시 파일이 전송되지 않는 것 수정, 잘못된 파일이름 다운로드 요청시 빈 리스트 전송으로 수정

### DIFF
--- a/nest_clinet_0616/src/org/kosa/nest/network/ReceiveWorker.java
+++ b/nest_clinet_0616/src/org/kosa/nest/network/ReceiveWorker.java
@@ -121,6 +121,8 @@ public class ReceiveWorker {
                 data = ois.read();
             }
             bos.flush();
+            bos.close();
+            System.out.println("다운로드 완료");
 
         } finally {
 //            if (bos != null)

--- a/nest_server_0616/src/org/kosa/nest/network/NetworkWorker.java
+++ b/nest_server_0616/src/org/kosa/nest/network/NetworkWorker.java
@@ -45,7 +45,6 @@ public class NetworkWorker {
 				ReceiveWorker receiveWorker = new ReceiveWorker(socket);
 				Thread receiveWorkerThread = new Thread(receiveWorker);
 				receiveWorkerThread.start();
-//				socket.close();
 			}
 		} finally {
 			if(serverSocket != null)
@@ -95,7 +94,6 @@ public class NetworkWorker {
 			oos = new ObjectOutputStream(socket.getOutputStream());
 			String commandLine  = br.readLine();
 			System.out.println("commandLine: " + commandLine);
-//			br.close();
 			
 			return commandLine;
 		}
@@ -116,16 +114,20 @@ public class NetworkWorker {
 				String command = st.nextToken();
 				
 				if(command.equalsIgnoreCase("download")) {
-					FileVO downloadFile = serverUserService.download(commandLine);
-					oos.writeObject(downloadFile);
+					ArrayList<FileVO> downloadFileList = serverUserService.download(commandLine);
+					oos.writeObject(downloadFileList);
 					oos.flush();
-					bis = new BufferedInputStream(new FileInputStream(downloadFile.getFileLocation()), 8192);
-					int data = bis.read();
-					while(data != -1) {
-						oos.write(data);
-						bis.read();
+					if(downloadFileList.size() > 0) {
+						bis = new BufferedInputStream(new FileInputStream(downloadFileList.get(0).getFileLocation()), 8192);
+						int data = bis.read();
+						while(data != -1) {
+							oos.write(data);
+						data = bis.read();
+						oos.flush();
+						}
+					} else {
+						oos.write(-1);
 					}
-					oos.flush();
 				}
 				else if(command.equalsIgnoreCase("list") || command.equals("search")) {
 					ArrayList<FileVO> searchFileList = (ArrayList<FileVO>)serverUserService.search(commandLine);
@@ -143,10 +145,8 @@ public class NetworkWorker {
 					oos.flush();
 				}
 			} finally {
-//				if(oos != null)
-//					oos.close();
-//				if(bis != null)
-//					bis.close();
+				if(socket!= null)
+					socket.close();
 			}
 
 		}

--- a/nest_server_0616/src/org/kosa/nest/service/ServerUserService.java
+++ b/nest_server_0616/src/org/kosa/nest/service/ServerUserService.java
@@ -27,11 +27,10 @@ public class ServerUserService {
 	 * @throws FileNotFoundException 
 	 * @throws SQLException 
 	 */
-	public FileVO download(String commandLine) throws FileNotFoundException, SQLException {
+	public ArrayList<FileVO> download(String commandLine) throws FileNotFoundException, SQLException {
 		
 		//반환할 FileVO
 		ArrayList<FileVO> resultFileInfoList = null;
-		FileVO resultInfo = null;
 		
 		//StringTokenizer를 이용하여 명령어에서 키워드를 분리
 		StringTokenizer st = new StringTokenizer(commandLine);
@@ -40,14 +39,12 @@ public class ServerUserService {
 		
 		//fileDao를 이용하여 키워드에 해당하는 파일의 정보를 찾아옴
 		resultFileInfoList = fileDao.getFileInfo(keyword);
-		if(resultFileInfoList.size() > 0)
-			resultInfo = resultFileInfoList.get(0);
+
 		//저장소에 해당 파일이 없다면 fildDao를 이용하여 db에 파일 정보 삭제하고 null값 반환
-		System.out.println(resultInfo.getFileLocation());
-		if(resultInfo != null && !new File(resultInfo.getFileLocation()).isFile()) {
+		if(resultFileInfoList.size() > 0 && !new File(resultFileInfoList.get(0).getFileLocation()).isFile()) {
 			throw new FileNotFoundException();
 		}
-		return resultInfo;
+		return resultFileInfoList;
 	}
 	/**
 	 * search : 파일의 일부 정보만 


### PR DESCRIPTION
개요

1. 클라이언트에서 서버에 다운로드 요청 시, 해당 파일 제목 가진 파일은 생성되었으나, 내용이 없는 문제 해결
-> server에서 socket을 닫아주어 해결
2. 클라이언트에서 서버에 존재하지 않는 파일을 다운로드 요청 시 에러 발생
-> 원래 FileVO 객체에 null을 전송하는 것에서 빈 ArrayList<FileVO> 객체를 전송하는 것으로 수정, 클라이언트에서 빈 ArrayList<FileVO>를 받아 처리