### PR TITLE
hot fix: DB에 잘못된 파일 주소 저장되는 것 수정, IOException 발생시 UploadFileFailException 발생하도록 수정

### DIFF
--- a/nest_server_0616/src/org/kosa/nest/service/ServerAdminService.java
+++ b/nest_server_0616/src/org/kosa/nest/service/ServerAdminService.java
@@ -186,15 +186,17 @@ public class ServerAdminService {
 			
 			BufferedInputStream bis = null;
 			BufferedOutputStream bos = null;
+			
+			File outputFile = null;
 			try {
-				fileDao.createFileInfo(inputFileInfo);
 				
 				File nestServerDir = new File(ServerConfig.REPOPATH);
 				if(!nestServerDir.isDirectory())
 					nestServerDir.mkdirs();
 
 				File inputFile = new File(inputFileInfo.getFileLocation());
-				File outputFile = new File(ServerConfig.REPOPATH + File.separator + inputFile.getName());
+				String outputFileAddress = ServerConfig.REPOPATH + File.separator + inputFile.getName();
+				outputFile = new File(outputFileAddress);
 			
 				// 파일 입출력
 				bis = new BufferedInputStream(new FileInputStream(inputFile), 8192);
@@ -205,10 +207,14 @@ public class ServerAdminService {
 					bos.write(data);
 					data = bis.read();
 				}
+				inputFileInfo.setFileLocation(outputFileAddress);
+				fileDao.createFileInfo(inputFileInfo);
 				System.out.println("File upload success!");
-			} catch(Exception e) {
-				throw new UploadFileFailException("File upload failed:" + e.getMessage());
-			
+			} catch(IOException e) {
+				throw new UploadFileFailException("File upload failed:" + e.getMessage());			
+			} catch(SQLException e) {
+				outputFile.delete();
+				throw new UploadFileFailException("File upload failed:" + e.getMessage());			
 			} finally {
 				if(bis != null)
 					bis.close();


### PR DESCRIPTION
개요
 UserClient에서 파일을 다운로드 실패하는 것을 확인, 그 원인이 DB에 저장되어있는 파일의 주소가 잘못되어 있다는 것을 확인.
fileUpload() 시 DB에 잘못된 주소값이 들어가고 있는 것을 확인하여 nestServer 디렉토리에 저장된 파일의 주소가 DB에 저장되도록 수정

fileUpload()에서 nestServer디렉토리로 파일 전송할 때 IOException 발생 시, UploadFileFailException 발생하도록 수정
IOException 또한 여전히 메서드에서 발생할 수 있는데, 이것은 bis, bos의 close() 시 발생할 수 있는 Exception임

테스트 결과
파일 전송 오류 없이 잘 작동하는 것 확인