### PR TITLE
refactor: ip, port번호를 저장하는 NestConfig 인터페이스 생성, ip port번호 사용하는 code 수정

### DIFF
--- a/nest_clinet_0616/src/org/kosa/nest/common/NestConfig.java
+++ b/nest_clinet_0616/src/org/kosa/nest/common/NestConfig.java
@@ -1,0 +1,10 @@
+package org.kosa.nest.common;
+
+/**
+ * 네트워크 연결에 사용되는 ip와 port번호를 저장하는 인터페이스입니다.
+ */
+public interface NestConfig {
+	
+	String ip = "127.0.0.1";
+	int port = 9876;
+}

--- a/nest_clinet_0616/src/org/kosa/nest/network/ReceiveWorker.java
+++ b/nest_clinet_0616/src/org/kosa/nest/network/ReceiveWorker.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.StringTokenizer;
 
 import org.kosa.nest.common.ClientConfig;
+import org.kosa.nest.common.NestConfig;
 import org.kosa.nest.exception.FileNotFoundException;
 import org.kosa.nest.model.FileVO;
 
@@ -23,8 +24,6 @@ public class ReceiveWorker {
     private ObjectInputStream ois;
     private BufferedOutputStream bos;
 
-    private String ip = "192.168.210.27"; // 서버 ip
-
     /**
      * ReceiveWorker 생성자로 socket 생성해 서버와 연결 <br>
      * 
@@ -32,7 +31,7 @@ public class ReceiveWorker {
      * @throws IOException
      */
     public ReceiveWorker() throws UnknownHostException, IOException {
-        socket = new Socket(ip, 9876);
+        socket = new Socket(NestConfig.ip, NestConfig.port);
     }
 
     /**

--- a/nest_server_0616/src/org/kosa/nest/common/NestConfig.java
+++ b/nest_server_0616/src/org/kosa/nest/common/NestConfig.java
@@ -1,0 +1,9 @@
+package org.kosa.nest.common;
+
+/**
+ * 네트워크 연결에 사용되는 port번호를 저장하는 인터페이스입니다.
+ */
+public interface NestConfig {
+	
+	int port = 9876;
+}

--- a/nest_server_0616/src/org/kosa/nest/network/NetworkWorker.java
+++ b/nest_server_0616/src/org/kosa/nest/network/NetworkWorker.java
@@ -14,6 +14,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.StringTokenizer;
 
+import org.kosa.nest.common.NestConfig;
 import org.kosa.nest.model.FileVO;
 import org.kosa.nest.service.ServerUserService;
 
@@ -35,7 +36,7 @@ public class NetworkWorker {
 	public void go() throws IOException {
 		ServerSocket serverSocket = null;
 		try {
-			serverSocket = new ServerSocket(9876);
+			serverSocket = new ServerSocket(NestConfig.port);
 			while(true){
 				Socket socket = serverSocket.accept();
 				ReceiveWorker receiveWorker = new ReceiveWorker(socket);


### PR DESCRIPTION
개요
Client의 ReceiveWorker와 Server의 NetworkWorker에 직접 적혀있던 ip와 port번호를 
NestConfig Interface에 저장하도록 수정
기존에 ip와 port번호 직접 사용하던 ReceiveWorker, NetworkWorker 코드 수정

테스트
통신에 이상 없음 확인
