### PR TITLE
chore : Client의 CommandLineInterface 클래스를 org.kosa.nest.client로 옮김

### DIFF
--- a/nest_clinet_0616/src/org/kosa/nest/NestMain.java
+++ b/nest_clinet_0616/src/org/kosa/nest/NestMain.java
@@ -2,6 +2,7 @@ package org.kosa.nest;
 
 import java.io.IOException;
 
+import org.kosa.nest.client.CommandLineInterface;
 import org.kosa.nest.exception.DataProcessException;
 import org.kosa.nest.exception.FileNotFoundException;
 import org.kosa.nest.exception.ServerConnectException;

--- a/nest_clinet_0616/src/org/kosa/nest/client/CommandLineInterface.java
+++ b/nest_clinet_0616/src/org/kosa/nest/client/CommandLineInterface.java
@@ -1,4 +1,4 @@
-package org.kosa.nest;
+package org.kosa.nest.client;
 
 import java.io.IOException;
 import java.net.UnknownHostException;


### PR DESCRIPTION
개요

Client의 CommandLineInterface 클래스를 org.kosa.nest에서 org.kosa.nest.client로 옮겨
클래스의 분류와 모듈화를 더욱 정확하게 하고자 함

테스트
전체 테스트시 잘 작동함