### PR TITLE
feat : Sever에서 빈 명령어 받았을 때 에러 처리

### DIFF
--- a/nest_server_0616/src/org/kosa/nest/client/CommandLineInterface.java
+++ b/nest_server_0616/src/org/kosa/nest/client/CommandLineInterface.java
@@ -10,6 +10,7 @@ import org.kosa.nest.exception.AdminNotLoginException;
 import org.kosa.nest.exception.FileNotDeletedInDatabase;
 import org.kosa.nest.exception.FileNotFoundException;
 import org.kosa.nest.exception.LoginException;
+import org.kosa.nest.exception.NoCommandLineException;
 import org.kosa.nest.exception.PasswordNotCorrectException;
 import org.kosa.nest.exception.RegisterAdminFailException;
 import org.kosa.nest.exception.SearchDatabaseException;
@@ -87,14 +88,19 @@ public class CommandLineInterface {
 					System.err.println(e.getMessage());
 				} catch (FileNotDeletedInDatabase e) {
 					System.err.println(e.getMessage());
+				} catch (NoCommandLineException e) {
+					System.err.println(e.getMessage());
 				}
 			}
 		}
 		
-		public String getCommand() throws LoginException, AdminNotLoginException, SQLException, IOException, PasswordNotCorrectException, UpdateAdminInfoFailException, FileNotFoundException, SearchDatabaseException, RegisterAdminFailException, UploadFileFailException, FileNotDeletedInDatabase {
+		public String getCommand() throws LoginException, AdminNotLoginException, SQLException, IOException, PasswordNotCorrectException, UpdateAdminInfoFailException, FileNotFoundException, SearchDatabaseException, RegisterAdminFailException, UploadFileFailException, FileNotDeletedInDatabase, NoCommandLineException {
 			
 			String commandLine = scanner.nextLine();
 			StringTokenizer st = new StringTokenizer(commandLine);
+			if(!st.hasMoreTokens()) {
+				throw new NoCommandLineException("Please enter commandline!");
+			}
 			String command = st.nextToken();
 			String keyword = null;
 			if(st.hasMoreTokens())

--- a/nest_server_0616/src/org/kosa/nest/exception/NoCommandLineException.java
+++ b/nest_server_0616/src/org/kosa/nest/exception/NoCommandLineException.java
@@ -1,0 +1,10 @@
+package org.kosa.nest.exception;
+
+public class NoCommandLineException extends Exception {
+
+	private static final long serialVersionUID = 1L;
+
+	public NoCommandLineException(String message) {
+		super(message);
+	}
+}


### PR DESCRIPTION
개요
서버 프로그램에서 빈 명령어를 받았을때 NoElement 오류가 나는 것 처리

구현
StringToknizer의 토큰을 읽기 전, 토큰이 있는지 확인하고 없다면 NoCommandException 던짐

테스트
잘 작동함 전체 테스트 완료