### PR TITLE
refactor: 단일 책임 원칙 적용하여 CommandLineInterface를 ThreadHandler 클래스로 나눔

### DIFF
--- a/nest_server_0616/src/org/kosa/nest/NestServerMain.java
+++ b/nest_server_0616/src/org/kosa/nest/NestServerMain.java
@@ -1,10 +1,10 @@
 package org.kosa.nest;
 
-import org.kosa.nest.client.CommandLineInterface;
+import org.kosa.nest.commandHandler.ThreadHandler;
 
 public class NestServerMain {
 	public static void main(String[] args) {
-		CommandLineInterface cli = new CommandLineInterface();
-		cli.executeProgram();
+		ThreadHandler threadHandler = new ThreadHandler();
+		threadHandler.executeProgram();
 	}
 }

--- a/nest_server_0616/src/org/kosa/nest/client/CommandLineInterface.java
+++ b/nest_server_0616/src/org/kosa/nest/client/CommandLineInterface.java
@@ -26,161 +26,77 @@ public class CommandLineInterface {
 	Scanner scanner;
 	NetworkWorker networkWorker;
 	ServerAdminService serverAdminService;
-	
+
 	public CommandLineInterface() {
 		networkWorker = new NetworkWorker();
 		scanner = new Scanner(System.in);
-		serverAdminService = new ServerAdminService(scanner); 
+		serverAdminService = new ServerAdminService(scanner);
 	}
-	
-	public void executeProgram() {
-        String logo = """
-                ███╗   ██╗███████╗███████╗████████╗
-                ████╗  ██║██╔════╝██╔════╝╚══██╔══╝
-                ██╔██╗ ██║█████╗  ███████╗   ██║   
-                ██║╚██╗██║██╔══╝  ╚════██║   ██║   
-                ██║ ╚████║███████╗███████║   ██║   
-                ╚═╝  ╚═══╝╚══════╝╚══════╝   ╚═╝   
-                                                
-                              	NEST 
-                          
-                    A neat place for your files.
-                """;
-        System.out.println(logo);
-		Thread serverThread = new Thread(new ServerThread());
-		Thread clientThread = new Thread(new clientThread());
-		
-		serverThread.setDaemon(true);
-		
-		clientThread.start();
-		serverThread.start();
-	}
-	
-	class ServerThread implements Runnable{
-		
-		
-		@Override
-		public void run(){
-			try {
-				networkWorker.go();
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
-		}
-	}
-	
-	class clientThread implements Runnable{
-		
-		@Override
-		public void run() {
-			while(true) {
-				try {
-					String commandLine = getCommand();
-					if(commandLine.equalsIgnoreCase("quit"))
-						break;
-				}catch (RegisterAdminFailException e) {
-					System.err.println(e.getMessage());	
-				} catch (LoginException e) {
-					System.err.println(e.getMessage());	
-				} catch (AdminNotLoginException e) {
-					System.err.println(e.getMessage());	
-				} catch (PasswordNotCorrectException e) {
-					System.err.println(e.getMessage());
-				} catch (UpdateAdminInfoFailException e) {
-					System.err.println(e.getMessage());
-				} catch (FileNotFoundException e) {
-					System.err.println(e.getMessage());
-				} catch (SearchDatabaseException e) {
-					System.err.println(e.getMessage());
-				} catch (SQLException e) {
-					System.err.println(e.getMessage());
-				} catch (IOException e) {
-					System.err.println(e.getMessage());
-				} catch (UploadFileFailException e) {
-					System.err.println(e.getMessage());
-				} catch (FileNotDeletedInDatabase e) {
-					System.err.println(e.getMessage());
-				} catch (NoCommandLineException e) {
-					System.err.println(e.getMessage());
-				}
-			}
-		}
-		
-		public String getCommand() throws LoginException, AdminNotLoginException, SQLException, IOException, PasswordNotCorrectException, UpdateAdminInfoFailException, FileNotFoundException, SearchDatabaseException, RegisterAdminFailException, UploadFileFailException, FileNotDeletedInDatabase, NoCommandLineException {
-			
-			String commandLine = scanner.nextLine();
-			StringTokenizer st = new StringTokenizer(commandLine);
-			if(!st.hasMoreTokens()) {
-				throw new NoCommandLineException("Please enter commandline!");
-			}
-			String command = st.nextToken();
-			String keyword = null;
-			if(st.hasMoreTokens())
-				keyword = st.nextToken();
-			
-			if(command.equalsIgnoreCase("quit") || command.equalsIgnoreCase("exit")){
-				scanner.close();
-			}
-			else if(command.equalsIgnoreCase("register")) {
-				serverAdminService.register();
-			}
-			else if(command.equalsIgnoreCase("login")) {
-				serverAdminService.login();
-			}
-			else if(command.equalsIgnoreCase("logout")) {
-				serverAdminService.logout();
-			}
-			else if(command.equalsIgnoreCase("getMyInformation")) {
-				resultToString(serverAdminService.getMyInformation());
-			}
-			else if(command.equalsIgnoreCase("updateMyInformation")) {
-				serverAdminService.updateMyInformation();
-			}
-			else if(command.equalsIgnoreCase("uploadFile")) {
-				serverAdminService.uploadFile();
-			}
-			else if(command.equalsIgnoreCase("deleteFile")) {
-				serverAdminService.deleteFile(keyword);
-			}
-			else if(command.equalsIgnoreCase("search")) {
-				resultToString(serverAdminService.search(keyword));
-			}
-			else if(command.equalsIgnoreCase("info")) {
-				resultToString(serverAdminService.info(keyword));
-			}
-			else if(command.equalsIgnoreCase("help")) {
-				serverAdminService.help();
-			}
-			else if(command.equalsIgnoreCase("findAllList")) {
-				resultToString(serverAdminService.findAllList());
-			}
-			else {
-				System.out.println("wrong command. If you need help, enter 'nest help'");
-			}
-			return command;
-		}
-		
-	}
-	
-	public void resultToString(AdminVO adminVO) {
-	    if (adminVO == null) {
-	        System.out.println("관리자 정보가 없습니다.");
-	        return;
-	    }
 
-	    System.out.println("admin id: " + adminVO.getId());
-	    System.out.println("email: " + adminVO.getEmail());
-	    System.out.println("password: " + adminVO.getPassword());
+	public String getCommand() throws LoginException, AdminNotLoginException, SQLException, IOException,
+			PasswordNotCorrectException, UpdateAdminInfoFailException, FileNotFoundException, SearchDatabaseException,
+			RegisterAdminFailException, UploadFileFailException, FileNotDeletedInDatabase, NoCommandLineException {
+
+		String commandLine = scanner.nextLine();
+		StringTokenizer st = new StringTokenizer(commandLine);
+		if (!st.hasMoreTokens()) {
+			throw new NoCommandLineException("Please enter commandline!");
+		}
+		String command = st.nextToken();
+		String keyword = null;
+		if (st.hasMoreTokens())
+			keyword = st.nextToken();
+
+		if (command.equalsIgnoreCase("quit") || command.equalsIgnoreCase("exit")) {
+			scanner.close();
+		} else if (command.equalsIgnoreCase("register")) {
+			serverAdminService.register();
+		} else if (command.equalsIgnoreCase("login")) {
+			serverAdminService.login();
+		} else if (command.equalsIgnoreCase("logout")) {
+			serverAdminService.logout();
+		} else if (command.equalsIgnoreCase("getMyInformation")) {
+			resultToString(serverAdminService.getMyInformation());
+		} else if (command.equalsIgnoreCase("updateMyInformation")) {
+			serverAdminService.updateMyInformation();
+		} else if (command.equalsIgnoreCase("uploadFile")) {
+			serverAdminService.uploadFile();
+		} else if (command.equalsIgnoreCase("deleteFile")) {
+			serverAdminService.deleteFile(keyword);
+		} else if (command.equalsIgnoreCase("search")) {
+			resultToString(serverAdminService.search(keyword));
+		} else if (command.equalsIgnoreCase("info")) {
+			resultToString(serverAdminService.info(keyword));
+		} else if (command.equalsIgnoreCase("help")) {
+			serverAdminService.help();
+		} else if (command.equalsIgnoreCase("findAllList")) {
+			resultToString(serverAdminService.findAllList());
+		} else {
+			System.out.println("wrong command. If you need help, enter 'nest help'");
+		}
+		return command;
 	}
-	
+
+
+	public void resultToString(AdminVO adminVO) {
+		if (adminVO == null) {
+			System.out.println("관리자 정보가 없습니다.");
+			return;
+		}
+
+		System.out.println("admin id: " + adminVO.getId());
+		System.out.println("email: " + adminVO.getEmail());
+		System.out.println("password: " + adminVO.getPassword());
+	}
+
 	public void resultToString(List<FileVO> fileList) {
-		for(FileVO vo : fileList)
+		for (FileVO vo : fileList)
 			System.out.println(vo.getSubject());
 	}
-	
+
 	public void resultToString(FileVO fileVO) {
-		if(fileVO == null)
-			return ;
+		if (fileVO == null)
+			return;
 		System.out.println("subject: " + fileVO.getSubject());
 		System.out.println("tag: " + fileVO.getTag());
 		System.out.println("lastModifed time: " + fileVO.getCreatedAt());
@@ -188,5 +104,5 @@ public class CommandLineInterface {
 		System.out.println("description: " + fileVO.getDescription());
 		System.out.println("server upload time: " + fileVO.getUploadAt());
 	}
-	
+
 }

--- a/nest_server_0616/src/org/kosa/nest/commandHandler/ThreadHandler.java
+++ b/nest_server_0616/src/org/kosa/nest/commandHandler/ThreadHandler.java
@@ -1,0 +1,103 @@
+package org.kosa.nest.commandHandler;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import org.kosa.nest.client.CommandLineInterface;
+import org.kosa.nest.exception.AdminNotLoginException;
+import org.kosa.nest.exception.FileNotDeletedInDatabase;
+import org.kosa.nest.exception.FileNotFoundException;
+import org.kosa.nest.exception.LoginException;
+import org.kosa.nest.exception.NoCommandLineException;
+import org.kosa.nest.exception.PasswordNotCorrectException;
+import org.kosa.nest.exception.RegisterAdminFailException;
+import org.kosa.nest.exception.SearchDatabaseException;
+import org.kosa.nest.exception.UpdateAdminInfoFailException;
+import org.kosa.nest.exception.UploadFileFailException;
+import org.kosa.nest.network.NetworkWorker;
+
+public class ThreadHandler {
+	
+	private NetworkWorker networkWorker;
+	private CommandLineInterface commandLineInterface;
+	
+	public ThreadHandler() {
+		networkWorker = new NetworkWorker();
+		commandLineInterface = new CommandLineInterface();
+	}
+
+	public void executeProgram() {
+        String logo = """
+                ███╗   ██╗███████╗███████╗████████╗
+                ████╗  ██║██╔════╝██╔════╝╚══██╔══╝
+                ██╔██╗ ██║█████╗  ███████╗   ██║   
+                ██║╚██╗██║██╔══╝  ╚════██║   ██║   
+                ██║ ╚████║███████╗███████║   ██║   
+                ╚═╝  ╚═══╝╚══════╝╚══════╝   ╚═╝   
+                                                
+                              	NEST 
+                          
+                    A neat place for your files.
+                """;
+        System.out.println(logo);
+		Thread serverThread = new Thread(new ServerThread());
+		Thread clientThread = new Thread(new clientThread());
+		
+		serverThread.setDaemon(true);
+		
+		clientThread.start();
+		serverThread.start();
+	}
+	
+	class ServerThread implements Runnable{
+		
+		
+		@Override
+		public void run(){
+			try {
+				networkWorker.go();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+	
+	class clientThread implements Runnable{
+		
+		@Override
+		public void run() {
+			while(true) {
+				try {
+					String commandLine = commandLineInterface.getCommand();
+					if(commandLine.equalsIgnoreCase("quit"))
+						break;
+				}catch (RegisterAdminFailException e) {
+					System.err.println(e.getMessage());	
+				} catch (LoginException e) {
+					System.err.println(e.getMessage());	
+				} catch (AdminNotLoginException e) {
+					System.err.println(e.getMessage());	
+				} catch (PasswordNotCorrectException e) {
+					System.err.println(e.getMessage());
+				} catch (UpdateAdminInfoFailException e) {
+					System.err.println(e.getMessage());
+				} catch (FileNotFoundException e) {
+					System.err.println(e.getMessage());
+				} catch (SearchDatabaseException e) {
+					System.err.println(e.getMessage());
+				} catch (SQLException e) {
+					System.err.println(e.getMessage());
+				} catch (IOException e) {
+					System.err.println(e.getMessage());
+				} catch (UploadFileFailException e) {
+					System.err.println(e.getMessage());
+				} catch (FileNotDeletedInDatabase e) {
+					System.err.println(e.getMessage());
+				} catch (NoCommandLineException e) {
+					System.err.println(e.getMessage());
+				}
+			}
+		}
+		
+	}
+}


### PR DESCRIPTION
- 개요
단일 책임 원칙을 적용

- 구현 내용
CommandLineInterface에 위치한 ExcuteProgram 메서드를 단일 책임 원칙에 근거해 ThreadHandler 클래스로 분리
분리한 이유? CommandLineInterface에서는 명령어 입력만 처리하고 프로그램 실행에 관한 부분(쓰레드 생성) ThreadHandler 클래스에서 처리하도록 변경

- 테스트 방법
수정 이후 프로그램 실행시켜봄
