### PR TITLE
refactor: Command Interface 작성

### DIFF
--- a/nest_server_0616/src/org/kosa/nest/command/Command.java
+++ b/nest_server_0616/src/org/kosa/nest/command/Command.java
@@ -1,0 +1,8 @@
+package org.kosa.nest.command;
+
+import java.util.List;
+
+public interface Command {
+	
+	List<Object> handleRequest(String command);
+}


### PR DESCRIPTION
개요
nest_server 클래스에 CommandPattern 적용하기 위해서 먼저 Command interface 작성
구현 내용
우선 Command interface만 작성하고 이후 이것을 적용한 Command 구현체들을 작성.
ServerAdminService와 ServerUserService의 메서드들을 분리하여 Command 구현체에 작성

테스트 방법
