### PR TITLE
fix : 원하는 이름의 커맨드만 반환하도록 변경

### DIFF
--- a/nest_server_0616/src/org/kosa/nest/handlerMapping/CommandHandlerMapping.java
+++ b/nest_server_0616/src/org/kosa/nest/handlerMapping/CommandHandlerMapping.java
@@ -20,9 +20,9 @@ public class CommandHandlerMapping {
 		return instance;
 	}
 	
-	public Command create() throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException {
+	public Command create(String command) throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException {
 		
-		Command command = null;
+		Command resultCommand = null;
 		
 		Reflections reflections = new Reflections(Command.class.getPackageName());
 		
@@ -30,9 +30,12 @@ public class CommandHandlerMapping {
 		
 		for(Class<? extends Command> clazz : classes ) {
 			if(!clazz.isInterface() && !Modifier.isAbstract(clazz.getModifiers())) {
-				command = clazz.getDeclaredConstructor().newInstance();
+			    if (clazz.getName().equalsIgnoreCase(command + "Command")) {
+					resultCommand = clazz.getDeclaredConstructor().newInstance();
+
+			    }
 			}
 		}
-		return command;		
+		return resultCommand;		
 	}
 }


### PR DESCRIPTION
개요
원하는 이름의 커맨드 클래스만을 생성하여 반환하도록 수정

구현내용
원래 for문에서는 interface가 아니고 abstract class가 아닌 모든 객체를 생성하였지만,
이를 수정하여 원하는 이름의 클래스만 객체를 생성하여 반환하도록 함