### PR TITLE
fix : 명령어 테스트 후 발생하는 오류 수정

### DIFF
--- a/nest_server_0616/src/org/kosa/nest/client/CommandLineInterface.java
+++ b/nest_server_0616/src/org/kosa/nest/client/CommandLineInterface.java
@@ -3,11 +3,9 @@ package org.kosa.nest.client;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
 
-import org.kosa.nest.common.ScannerWrapper;
 import org.kosa.nest.exception.AdminNotLoginException;
 import org.kosa.nest.exception.FileNotDeletedInDatabase;
 import org.kosa.nest.exception.FileNotFoundException;
@@ -18,8 +16,6 @@ import org.kosa.nest.exception.RegisterAdminFailException;
 import org.kosa.nest.exception.SearchDatabaseException;
 import org.kosa.nest.exception.UpdateAdminInfoFailException;
 import org.kosa.nest.exception.UploadFileFailException;
-import org.kosa.nest.model.AdminVO;
-import org.kosa.nest.model.FileVO;
 import org.kosa.nest.network.NetworkWorker;
 import org.kosa.nest.service.ServerAdminService;
 
@@ -33,7 +29,9 @@ public class CommandLineInterface {
 	}
 	
 	public static CommandLineInterface getInstance() {
-		return instance = new CommandLineInterface();
+		if(instance == null)
+			instance = new CommandLineInterface();
+		return instance;
 	}
 
 	public String getCommand(String commandLine) throws LoginException, AdminNotLoginException, SQLException, IOException,

--- a/nest_server_0616/src/org/kosa/nest/command/admin/DeleteFileCommand.java
+++ b/nest_server_0616/src/org/kosa/nest/command/admin/DeleteFileCommand.java
@@ -2,10 +2,10 @@ package org.kosa.nest.command.admin;
 
 import java.io.File;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.kosa.nest.command.AdminCommand;
-import org.kosa.nest.command.Command;
 import org.kosa.nest.common.NestConfig;
 import org.kosa.nest.exception.AdminNotLoginException;
 import org.kosa.nest.exception.FileNotDeletedInDatabase;
@@ -44,7 +44,7 @@ public class DeleteFileCommand extends AdminCommand {
             }
             System.out.println("File delete success");
         }
-        return null;
+        return new ArrayList<Object>();
     }
 
 }

--- a/nest_server_0616/src/org/kosa/nest/command/admin/FindAllListCommand.java
+++ b/nest_server_0616/src/org/kosa/nest/command/admin/FindAllListCommand.java
@@ -4,7 +4,6 @@ import java.sql.SQLException;
 import java.util.List;
 
 import org.kosa.nest.command.AdminCommand;
-import org.kosa.nest.command.Command;
 import org.kosa.nest.exception.AdminNotLoginException;
 import org.kosa.nest.exception.SearchDatabaseException;
 import org.kosa.nest.model.FileDao;

--- a/nest_server_0616/src/org/kosa/nest/command/admin/GetMyInformationCommand.java
+++ b/nest_server_0616/src/org/kosa/nest/command/admin/GetMyInformationCommand.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.kosa.nest.command.AdminCommand;
-import org.kosa.nest.command.Command;
 import org.kosa.nest.exception.AdminNotLoginException;
 import org.kosa.nest.service.ServerAdminService;
 

--- a/nest_server_0616/src/org/kosa/nest/command/admin/HelpCommand.java
+++ b/nest_server_0616/src/org/kosa/nest/command/admin/HelpCommand.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.kosa.nest.command.AdminCommand;
-import org.kosa.nest.command.Command;
 
 public class HelpCommand extends AdminCommand {
 
@@ -22,31 +21,27 @@ public class HelpCommand extends AdminCommand {
     @Override
     public List<Object> handleRequest(String command) {
     	StringBuilder stringBuilder = new StringBuilder();
-    	stringBuilder.append("---- nest 프로그램 안내 ----");
-    	stringBuilder.append("nest는 로컬과 서버의 파일을 명령어 한 줄로 손쉽게 관리할 수 있는 CLI 기반 파일 관리 프로그램입니다.");
-    	stringBuilder.append("로컬 모드에서는 내 컴퓨터의 파일 목록 확인 및 삭제가 가능하며,");
-    	stringBuilder.append("서버 모드에서는 파일 검색, 상세 정보 확인, 다운로드를 지원합니다.");
-    	stringBuilder.append("모드를 선택한 후 다음 명령어를 사용할 수 있습니다:");
-    	stringBuilder.append("  list             - 로컬 파일 목록 보기");
-    	stringBuilder.append("  delete <파일명>   - 로컬 파일 삭제");
-    	stringBuilder.append("  delete <파일명>   - 로컬 파일 삭제");
-    	stringBuilder.append("  search <키워드>   - 서버에서 파일 검색");
-    	stringBuilder.append("  info <파일명>     - 서버 파일 상세 정보 보기");
-    	stringBuilder.append("  download <파일명> - 서버 파일 다운로드");
-    	stringBuilder.append("  exit             - 프로그램 종료");
-    	stringBuilder.append("\"---- 관리자 명령어 ----\"\n");
-		stringBuilder.append("  Register              - 관리자로 회원가입합니다");
-		stringBuilder.append("  Login                 - 로그인합니다");
-		stringBuilder.append("  Logout                - 로그아웃합니다");
-		stringBuilder.append("  GetMyInformation      - 로그인한 관리자의 정보를 조회합니다");
-		stringBuilder.append("  UpdateMyInformation   - 로그인한 관리자의 정보를 수정합니다");
-		stringBuilder.append("  UploadFile            - 파일을 업로드합니다");
-		stringBuilder.append("  DeleteFile            - 파일을 삭제합니다");
-		stringBuilder.append("  FindAllList           - 모든 파일 목록을 조회합니다");
-		stringBuilder.append("  Search                - 파일 이름으로 검색합니다 (파일 이름 필요)");
-		stringBuilder.append("  Info                  - 파일 상세 정보를 조회합니다 (파일 이름 필요)");
-		stringBuilder.append("  Delete                - 파일을 삭제합니다 (파일 이름 필요)");
-		
+    	stringBuilder.append("---- nest 프로그램 안내 ----\n");
+    	stringBuilder.append("nest는 로컬과 서버의 파일을 명령어 한 줄로 손쉽게 관리할 수 있는 CLI 기반 파일 관리 프로그램입니다.\n");
+    	stringBuilder.append("로컬 모드에서는 내 컴퓨터의 파일 목록 확인 및 삭제가 가능하며,\n");
+    	stringBuilder.append("서버 모드에서는 파일 검색, 상세 정보 확인, 다운로드를 지원합니다.\n");
+    	stringBuilder.append("모드를 선택한 후 다음 명령어를 사용할 수 있습니다:\n");
+    	stringBuilder.append("delete <파일명>			- 로컬 파일 삭제\n");
+    	stringBuilder.append("search <키워드>			- 서버에서 파일 검색\n");
+    	stringBuilder.append("info <파일명>			- 서버 파일 상세 정보 보기\n");
+    	stringBuilder.append("download <파일명>			- 서버 파일 다운로드\n");
+    	stringBuilder.append("exit / quit			- 프로그램 종료\n");
+    	stringBuilder.append("---- 관리자 명령어 ----\n");
+		stringBuilder.append("Register			- 관리자로 회원가입합니다\n");
+		stringBuilder.append("Login				- 로그인합니다\n");
+		stringBuilder.append("Logout				- 로그아웃합니다\n");
+		stringBuilder.append("GetMyInformation		- 로그인한 관리자의 정보를 조회합니다\n");
+		stringBuilder.append("UpdateMyInformation		- 로그인한 관리자의 정보를 수정합니다\n");
+		stringBuilder.append("UploadFile			- 파일을 업로드합니다\n");
+		stringBuilder.append("DeleteFile			- 파일을 삭제합니다\n");
+		stringBuilder.append("FindAllList			- 모든 파일 목록을 조회합니다\n");
+		stringBuilder.append("Search				- 파일 이름으로 검색합니다 (파일 이름 필요)\n");
+		stringBuilder.append("Info				- 파일 상세 정보를 조회합니다 (파일 이름 필요)\n");
 		List<Object> list = new ArrayList<Object>();
 		list.add(stringBuilder.toString());
         return list;

--- a/nest_server_0616/src/org/kosa/nest/command/admin/InfoCommand.java
+++ b/nest_server_0616/src/org/kosa/nest/command/admin/InfoCommand.java
@@ -5,10 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.kosa.nest.command.AdminCommand;
-import org.kosa.nest.command.Command;
 import org.kosa.nest.exception.SearchDatabaseException;
 import org.kosa.nest.model.FileDao;
-import org.kosa.nest.model.FileVO;
 
 public class InfoCommand extends AdminCommand {
 
@@ -27,7 +25,6 @@ public class InfoCommand extends AdminCommand {
     public List<Object> handleRequest(String keyword) throws SearchDatabaseException {
 
         List<Object> resultList = new ArrayList<>();
-        FileVO resultFileVO = null;
         try {
             resultList = FileDao.getInstance().getFileInfo(keyword);
         } catch (SQLException e) {

--- a/nest_server_0616/src/org/kosa/nest/command/admin/LogoutCommand.java
+++ b/nest_server_0616/src/org/kosa/nest/command/admin/LogoutCommand.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.kosa.nest.command.AdminCommand;
-import org.kosa.nest.command.Command;
 import org.kosa.nest.exception.AdminNotLoginException;
 import org.kosa.nest.service.ServerAdminService;
 

--- a/nest_server_0616/src/org/kosa/nest/command/admin/RegisterCommand.java
+++ b/nest_server_0616/src/org/kosa/nest/command/admin/RegisterCommand.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.kosa.nest.command.AdminCommand;
-import org.kosa.nest.command.Command;
 import org.kosa.nest.common.ScannerWrapper;
 import org.kosa.nest.exception.RegisterAdminFailException;
 import org.kosa.nest.model.AdminDao;
@@ -49,6 +48,7 @@ public class RegisterCommand extends AdminCommand {
             throw new RegisterAdminFailException("Register failed, Email already in use:" + e.getMessage()); // 사용자 정의
                                                                                                                 // 예외 전달
         }
+        System.out.println("admin register success");
         return list;
     }
 

--- a/nest_server_0616/src/org/kosa/nest/command/admin/SearchCommand.java
+++ b/nest_server_0616/src/org/kosa/nest/command/admin/SearchCommand.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.kosa.nest.command.AdminCommand;
-import org.kosa.nest.command.Command;
 import org.kosa.nest.exception.SearchDatabaseException;
 import org.kosa.nest.model.FileDao;
 

--- a/nest_server_0616/src/org/kosa/nest/command/admin/UpdateMyInformationCommand.java
+++ b/nest_server_0616/src/org/kosa/nest/command/admin/UpdateMyInformationCommand.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.kosa.nest.command.AdminCommand;
-import org.kosa.nest.command.Command;
 import org.kosa.nest.common.ScannerWrapper;
 import org.kosa.nest.exception.AdminNotLoginException;
 import org.kosa.nest.exception.PasswordNotCorrectException;
@@ -70,6 +69,7 @@ public class UpdateMyInformationCommand extends AdminCommand {
             } catch(SQLException e){
                 throw new UpdateAdminInfoFailException("Update Admin Information failed:" + e.getMessage());
             }
+            ServerAdminService.getInstance().setCurrentLoginAdmin(updatedAdmin);
             System.out.println("Update Admin Information success");
             return (List<Object>)list;
         }

--- a/nest_server_0616/src/org/kosa/nest/command/admin/UploadFileCommand.java
+++ b/nest_server_0616/src/org/kosa/nest/command/admin/UploadFileCommand.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.kosa.nest.command.AdminCommand;
-import org.kosa.nest.command.Command;
 import org.kosa.nest.common.NestConfig;
 import org.kosa.nest.common.ScannerWrapper;
 import org.kosa.nest.exception.AdminNotLoginException;
@@ -88,7 +87,7 @@ public class UploadFileCommand extends AdminCommand {
                     bos.close();
             }
         }
-        return null;
+        return new ArrayList<Object>();
     }
     
     /**
@@ -103,7 +102,7 @@ public class UploadFileCommand extends AdminCommand {
 
         System.out.print("tag:");
         String fileTag = ScannerWrapper.getInstance().nextLine();
-        System.out.println("dscription:");
+        System.out.print("description:");
         String fileDescription = ScannerWrapper.getInstance().nextLine();
         File inputFile = new File(fileAddress);
         LocalDateTime lastModifed = LocalDateTime.ofInstant(Instant.ofEpochMilli(inputFile.lastModified()),
@@ -114,5 +113,4 @@ public class UploadFileCommand extends AdminCommand {
 
         return fileVO;
     }
-
 }

--- a/nest_server_0616/src/org/kosa/nest/command/user/SearchCommand.java
+++ b/nest_server_0616/src/org/kosa/nest/command/user/SearchCommand.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.sql.SQLException;
 import java.util.List;
-import java.util.StringTokenizer;
 
 import org.kosa.nest.command.UserCommand;
 import org.kosa.nest.model.FileDao;

--- a/nest_server_0616/src/org/kosa/nest/model/AdminVO.java
+++ b/nest_server_0616/src/org/kosa/nest/model/AdminVO.java
@@ -47,7 +47,7 @@ public class AdminVO {
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append("admin id:").append(id).append("\n")
-			.append("email:").append(email).append("\n");
+			.append("email:").append(email);
 		return sb.toString();
 	}
 		

--- a/nest_server_0616/src/org/kosa/nest/model/FileDao.java
+++ b/nest_server_0616/src/org/kosa/nest/model/FileDao.java
@@ -40,16 +40,13 @@ public class FileDao {
 
         try {
             con = DatabaseUtil.getConnection();
-            String sql = "SELECT title, tag, created_at FROM file";
+            String sql = "SELECT title FROM file";
             pstmt = con.prepareStatement(sql);
             rs = pstmt.executeQuery();
 
             while (rs.next()) {
                 String title = rs.getString("title");
-                String tag = rs.getString("tag");
-                java.sql.Date createDate = rs.getDate("created_at");
-
-                list.add(new FileVO(title, tag, createDate));
+                list.add(title);
             }
         } finally {
             DatabaseUtil.closeAll(rs, pstmt, con);

--- a/nest_server_0616/src/org/kosa/nest/model/FileVO.java
+++ b/nest_server_0616/src/org/kosa/nest/model/FileVO.java
@@ -83,7 +83,7 @@ public class FileVO implements Serializable{
 			.append("Last Modified Time:").append(createdAt).append("\n")
 			.append("File Address:").append(fileLocation).append("\n")
 			.append("Description:").append(description).append("\n")
-			.append("Server Upload Time:").append(uploadAt).append("\n");
+			.append("Server Upload Time:").append(uploadAt);
 		return sb.toString();
 	}
 


### PR DESCRIPTION
개요
fix : 명령어 테스트 후 발생하는 오류 수정

구현내용
- updateMyInformation 명령어: DB 수정은 완료되나, getMyInformation 명령어로 확인해 보면 콘솔에서는 정보 수정 전에 ServerAdminService의 currentLoginAdmin을  들어와 있던 정보가 출력
    → 로그아웃을 시켜준다 or currentLoginAdmin을 업데이트
- register 명령어: 성공 후 성공 알림 필요
- deleteFile, uploadFile 명령어: 핸들러의 반환값인 list에서 null 값이 반환되어 NullPointerException 발생
    → return null이던 반환값을 new ArrayList<Object>();로 변경
- FindAllList 명령어: 결과 출력 시 toString을 이용하는 것이 아니라 List<String>으로 처리해 제목만 출력

테스트
명령어 테스트 완료함